### PR TITLE
Fix build steps attribute names

### DIFF
--- a/codefresh.yml
+++ b/codefresh.yml
@@ -14,7 +14,7 @@ steps:
     title: Build image
     type: build
     description: Build frontend
-    image-name: cloudpossedemo/frontend
+    image_name: cloudpossedemo/frontend
     dockerfile: Dockerfile
 
   semver:


### PR DESCRIPTION
## what
* Fix build steps attribute names

## why
* Using `-` in attribute names is obsolete
* The names should include only letters, digits and underscores
